### PR TITLE
chore: Update default Core version to 3.1.6-alpha

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,7 +12,7 @@ on:
       core_version:
         description: 'Core version to test'
         required: false
-        default: '3.0.0-alpha'
+        default: '3.1.6-alpha'
   # Disabled triggers:
   # push:
   #   branches: [main]


### PR DESCRIPTION
Updates the E2E test workflow to use Core v3.1.6-alpha which includes the Linux inference fix.

## Changes
- Updated default `core_version` from `3.0.0-alpha` to `3.1.6-alpha`

## Testing
- v3.1.6-alpha verified working on Ubuntu AMD64 (4/4 inference tests passed)
- v3.1.6-alpha verified working on macOS ARM64