### PR TITLE
fix: Use logarithmic scale for Installation chart

### DIFF
--- a/scripts/test-release-e2e.sh.bash
+++ b/scripts/test-release-e2e.sh.bash
@@ -1647,6 +1647,9 @@ generate_html_report() {
     
     log "Generating HTML report: $REPORT_FILE"
     
+    # Disable exit on error for report generation (sed/python may have issues)
+    set +e
+    
     cat > "$REPORT_FILE" << 'EOF'
 <!DOCTYPE html>
 <html lang="en">
@@ -2134,10 +2137,18 @@ generate_html_report() {
                 },
                 scales: {
                     y: {
-                        beginAtZero: true,
+                        type: 'logarithmic',
+                        min: 10,
                         title: {
                             display: true,
-                            text: 'Time (milliseconds)'
+                            text: 'Time (milliseconds) - Log Scale'
+                        },
+                        ticks: {
+                            callback: function(value) {
+                                if (value >= 1000000) return (value/1000000).toFixed(0) + 'M';
+                                if (value >= 1000) return (value/1000).toFixed(0) + 'K';
+                                return value;
+                            }
                         }
                     }
                 }
@@ -2608,6 +2619,9 @@ PYTHON_SCRIPT
     
     # Remove backup files created by sed (if any remain)
     rm -f "$REPORT_FILE.bak"
+    
+    # Re-enable exit on error
+    set -e
     
     log "✅ HTML report generated: $REPORT_FILE"
 }


### PR DESCRIPTION
## Problems Fixed

### 1. Installation Chart - Only Last Bar Visible
The chart only showed the Model Install bar because:
- Model Install: ~600,000 ms (10 minutes)
- Other operations: < 1,000 ms

At a linear scale of 0-600,000, values like 339, 792, and 127 are less than 0.2% of the chart height.

**Solution:** Changed to logarithmic scale with K/M suffixes.

### 2. Python Replacement Not Running (TIMESTAMP, NLP_STATUS, etc.)
The script has `set -e` which causes **silent exit** on ANY command failure. This was killing the script before the Python replacement could run.

**Solution:** Added `set +e` around report generation to allow processing to complete, then re-enable `set -e`.

## Expected Result
- All four bars visible in Installation chart
- All placeholders replaced (TIMESTAMP, TEST_DIR, NLP_STATUS, INFERENCE_METRICS_HTML, etc.)